### PR TITLE
Fix notebook_formats in _export_models function

### DIFF
--- a/mlflow_export_import/bulk/export_models.py
+++ b/mlflow_export_import/bulk/export_models.py
@@ -102,7 +102,7 @@ def _export_models(
     for model_name in model_names:
         _logger.info(f"  {model_name}")
 
-    notebook_formats = utils.string_to_list(notebook_formats),
+    notebook_formats = utils.string_to_list(notebook_formats)
     futures = []
     with ThreadPoolExecutor(max_workers=max_workers) as executor:
         for model_name in model_names:


### PR DESCRIPTION
It should not be a tuple. The extra comma made it a tuple.