### PR TITLE
Fixes: Adding version check and small fix

### DIFF
--- a/mlflow_export_import/bulk/export_logged_models.py
+++ b/mlflow_export_import/bulk/export_logged_models.py
@@ -16,6 +16,7 @@ from mlflow_export_import.common import MlflowExportImportException
 from mlflow_export_import.common import utils, io_utils, mlflow_utils
 from mlflow_export_import.bulk.bulk_utils import get_logged_models, get_experiment_ids
 from mlflow_export_import.logged_model.export_logged_model import export_logged_model
+from mlflow_export_import.common.version_utils import has_logged_model_support
 
 _logger = utils.getLogger(__name__)
 
@@ -33,6 +34,10 @@ def export_logged_models(
     :param logged_models_filter: Filter logged models based on run ids to experiments.
     :param mlflow_client: Mlflow client
     """
+    if not has_logged_model_support():
+        _logger.warning(f"Logged models are not supported in this MLflow version {mlflow.__version__} (requires 3.0+).")
+        return {"unsupported": True, "mlflow_version": mlflow.__version__}
+
     mlflow_client = mlflow_client or mlflow.MlflowClient()
 
     if isinstance(experiment_ids, str):

--- a/mlflow_export_import/bulk/export_traces.py
+++ b/mlflow_export_import/bulk/export_traces.py
@@ -15,6 +15,7 @@ from mlflow_export_import.common import MlflowExportImportException
 from mlflow_export_import.bulk.bulk_utils import get_experiment_ids, get_traces
 from mlflow_export_import.common import utils, mlflow_utils, io_utils
 from mlflow_export_import.trace.export_trace import export_trace
+from mlflow_export_import.common.version_utils import has_trace_support
 
 _logger = utils.getLogger(__name__)
 
@@ -32,6 +33,9 @@ def export_traces(
     :param run_id: Run id to filter during search
     :param mlflow_client: Mlflow client
     """
+    if not has_trace_support():
+        _logger.warning(f"Traces are not supported in this MLflow version {mlflow.__version__} (requires 2.14+).")
+        return {"unsupported": True, "mlflow_version": mlflow.__version__}
 
     mlflow_client = mlflow_client or mlflow.MlflowClient()
     if isinstance(experiment_ids, str):

--- a/mlflow_export_import/bulk/import_logged_models.py
+++ b/mlflow_export_import/bulk/import_logged_models.py
@@ -12,6 +12,7 @@ from mlflow_export_import.common.click_options import (
 )
 from mlflow_export_import.common import utils, io_utils
 from mlflow_export_import.logged_model.import_logged_model import import_logged_model
+from mlflow_export_import.common.version_utils import has_logged_model_support
 
 _logger = utils.getLogger(__name__)
 
@@ -23,6 +24,10 @@ def import_logged_models(
     :param input_dir: Source Logged models directory
     :param mlflow_client: Mlflow client
     """
+    if not has_logged_model_support():
+        _logger.warning(f"Logged models are not supported in this MLflow version {mlflow.__version__} (requires 3.0+).")
+        return {"unsupported": True, "mlflow_version": mlflow.__version__}
+
     mlflow_client = mlflow_client or mlflow.MlflowClient()
     dct = io_utils.read_file_mlflow(os.path.join(input_dir, "logged_models.json"))
     exps = dct["experiments"]

--- a/mlflow_export_import/bulk/import_traces.py
+++ b/mlflow_export_import/bulk/import_traces.py
@@ -12,6 +12,7 @@ from mlflow_export_import.common.click_options import (
 )
 from mlflow_export_import.common import utils, io_utils
 from mlflow_export_import.trace.import_trace import import_trace
+from mlflow_export_import.common.version_utils import has_trace_support
 
 _logger = utils.getLogger(__name__)
 
@@ -23,6 +24,10 @@ def import_traces(
     :param input_dir: Source traces directory
     :param mlflow_client: Mlflow client
     """
+    if not has_trace_support():
+        _logger.warning(f"Traces are not supported in this MLflow version {mlflow.__version__} (requires 2.14+).")
+        return {"unsupported": True, "mlflow_version": mlflow.__version__}
+
     mlflow_client = mlflow_client or mlflow.MlflowClient()
     dct = io_utils.read_file_mlflow(os.path.join(input_dir, "traces.json"))
 

--- a/mlflow_export_import/common/version_utils.py
+++ b/mlflow_export_import/common/version_utils.py
@@ -29,6 +29,9 @@ def has_logged_model_support():
     """LoggedModel entity - first-class model objects (3.0.0+)."""
     return get_mlflow_version() >= version.parse("3.0.0")
 
+def has_assessments_support():
+    """Assessments entity - first-class model objects (3.2.0+)."""
+    return get_mlflow_version() >= version.parse("3.2.0")
 
 def has_evaluation_dataset_support():
     """Evaluation datasets stored in experiments (3.4.0+)."""

--- a/mlflow_export_import/experiment/export_experiment.py
+++ b/mlflow_export_import/experiment/export_experiment.py
@@ -21,6 +21,7 @@ from mlflow_export_import.common.iterators import SearchRunsIterator
 from mlflow_export_import.common import utils, io_utils, mlflow_utils
 from mlflow_export_import.common import ws_permissions_utils
 from mlflow_export_import.common.timestamp_utils import fmt_ts_millis, utc_str_to_millis
+from mlflow_export_import.common.version_utils import has_trace_support, has_logged_model_support
 from mlflow_export_import.client.client_utils import create_mlflow_client, create_dbx_client
 from mlflow_export_import.run.export_run import export_run
 from mlflow_export_import.bulk import (
@@ -106,7 +107,7 @@ def export_experiment(
     mlflow_attr = { "experiment": exp_dct , "runs": ok_run_ids }
 
     # Export Logged Models
-    if version.parse(mlflow.__version__) >= version.parse("3.0.0"):
+    if has_logged_model_support:
         ok_logged_models, failed_logged_models = export_logged_models.export_logged_models(
             experiment_ids = [exp.experiment_id],
             output_dir = os.path.join(output_dir, "logged_models"),
@@ -118,7 +119,7 @@ def export_experiment(
         mlflow_attr["logged_models"] = ok_logged_models
 
     # Export traces
-    if version.parse(mlflow.__version__) >= version.parse("2.14.0"):
+    if has_trace_support:
         ok_traces, failed_traces = export_traces.export_traces(
             experiment_ids=[exp.experiment_id],
             output_dir=os.path.join(output_dir, "traces"),

--- a/mlflow_export_import/experiment/import_experiment.py
+++ b/mlflow_export_import/experiment/import_experiment.py
@@ -4,6 +4,7 @@ Imports an experiment to a directory.
 
 import os
 import click
+from mlflow.entities import RunStatus
 
 from mlflow_export_import.common.click_options import (
     opt_experiment_name,
@@ -121,6 +122,10 @@ def import_experiment(
                     step = model['step'],
                 )
                 imported_logged_models.append(model['model_id'])
+
+        # in logged models after logging the metrics, run status is changing back to Finished. So setting the status again.
+        default_status = RunStatus.to_string(RunStatus.FINISHED)
+        mlflow_client.set_terminated(dst_run_id, src_run_dct.get("info", default_status).get("status", default_status))
 
         # Import traces associated to the run
         if src_run_dct.get("traces"):

--- a/mlflow_export_import/logged_model/export_logged_model.py
+++ b/mlflow_export_import/logged_model/export_logged_model.py
@@ -19,6 +19,7 @@ from mlflow_export_import.common.click_options import (
     opt_output_dir
 )
 from mlflow_export_import.common.timestamp_utils import format_seconds
+from mlflow_export_import.common.version_utils import has_logged_model_support
 
 _logger = utils.getLogger(__name__)
 
@@ -32,6 +33,9 @@ def export_logged_model(
     :param output_dir: Output directory
     :param mlflow_client: MLflow client
     """
+    if not has_logged_model_support():
+        _logger.warning(f"Logged models are not supported in this MLflow version {mlflow.__version__} (requires 3.0+).")
+        return {"unsupported": True, "mlflow_version": mlflow.__version__}
 
     mlflow_client = mlflow_client or create_mlflow_client()
     start_time = time.time()

--- a/mlflow_export_import/logged_model/import_logged_model.py
+++ b/mlflow_export_import/logged_model/import_logged_model.py
@@ -4,7 +4,8 @@ Imports a logged model from a directory
 
 import os
 import click
-from mlflow.entities import Metric, RunStatus
+import mlflow
+from mlflow.entities import RunStatus
 
 from mlflow_export_import.common import utils, mlflow_utils, io_utils
 from mlflow_export_import.common import filesystem as _fs
@@ -16,6 +17,7 @@ from mlflow_export_import.common import MlflowExportImportException
 from mlflow_export_import.client.client_utils import create_mlflow_client
 from mlflow_export_import.logged_model.logged_model_utils import update_logged_model_mlmodel_data
 from mlflow_export_import.logged_model.logged_model_importer import _import_inputs, _log_metrics
+from mlflow_export_import.common.version_utils import has_logged_model_support
 
 _logger = utils.getLogger(__name__)
 
@@ -38,6 +40,10 @@ def import_logged_model(
     :param step: Step to add Logged Model to run.
     :param mlflow_client: MLflow client.
     """
+    if not has_logged_model_support():
+        _logger.warning(f"Logged models are not supported in this MLflow version {mlflow.__version__} (requires 3.0+).")
+        return {"unsupported": True, "mlflow_version": mlflow.__version__}
+
     mlflow_client = mlflow_client or create_mlflow_client()
 
     _logger.info(f"Importing logged model from '{input_dir}'")

--- a/mlflow_export_import/model/import_model.py
+++ b/mlflow_export_import/model/import_model.py
@@ -296,6 +296,7 @@ class BulkModelImporter(BaseModelImporter):
 
     def import_version(self, model_name, src_vr, dst_run_id):
         src_run_id = src_vr["run_id"]
+        model_id = None
         if "models" in src_vr["source"]: # 3.x logged models
             model_id = self.mlflow_client.get_run(dst_run_id).outputs.model_outputs[0].model_id
             dst_source = _get_logged_model_artifact_path(model_id)
@@ -309,7 +310,8 @@ class BulkModelImporter(BaseModelImporter):
             src_vr = src_vr,
             dst_run_id = dst_run_id,
             dst_source = dst_source,
-            import_source_tags = self.import_source_tags
+            import_source_tags = self.import_source_tags,
+            model_id=model_id
         )
 
 

--- a/mlflow_export_import/trace/export_trace.py
+++ b/mlflow_export_import/trace/export_trace.py
@@ -21,6 +21,7 @@ from mlflow_export_import.trace.trace_utils import (
     _extract_span,
     _write_trace_id_to_run
 )
+from mlflow_export_import.common.version_utils import has_trace_support
 
 _logger = utils.getLogger(__name__)
 
@@ -34,6 +35,10 @@ def export_trace(
     :param output_dir: Output directory
     :param mlflow_client: Mlflow client
     """
+    if not has_trace_support():
+        _logger.warning(f"Traces are not supported in this MLflow version {mlflow.__version__} (requires 2.14+).")
+        return {"unsupported": True, "mlflow_version": mlflow.__version__}
+
     mlflow_client = mlflow_client or create_mlflow_client()
     experiment_id = None
     start_time = time.time()

--- a/mlflow_export_import/trace/import_trace.py
+++ b/mlflow_export_import/trace/import_trace.py
@@ -20,6 +20,7 @@ from mlflow_export_import.trace.trace_data_importer import (
     _import_assessments
 )
 from mlflow_export_import.trace.trace_utils import _try_parse_json, _get_span_attributes
+from mlflow_export_import.common.version_utils import has_trace_support
 
 _logger = utils.getLogger(__name__)
 
@@ -36,6 +37,10 @@ def import_trace(
     :param run_id: Run Id
     :param mlflow_client: Mlflow client
     """
+    if not has_trace_support():
+        _logger.warning(f"Traces are not supported in this MLflow version {mlflow.__version__} (requires 2.14+).")
+        return {"unsupported": True, "mlflow_version": mlflow.__version__}
+
     mlflow_client = mlflow_client or create_mlflow_client()
 
     exp = mlflow_utils.set_experiment(mlflow_client, None, experiment_name)

--- a/mlflow_export_import/trace/trace_data_importer.py
+++ b/mlflow_export_import/trace/trace_data_importer.py
@@ -11,6 +11,7 @@ from mlflow_export_import.trace.trace_utils import (
     _get_span_attributes,
     _get_span_params
 )
+from mlflow_export_import.common.version_utils import has_assessments_support
 
 
 def _import_span_data(dst_trace_id, dst_root_span_id, src_root_span_id, src_graph, src_span_map, mlflow_client):
@@ -79,7 +80,7 @@ def _add_span_events(dst_child_span, span_events):
             ))
 
 def _import_assessments(assessments, trace_id, src_dst_span_map):
-    if version.parse(mlflow.__version__) >= version.parse("3.4.0"):
+    if has_assessments_support() and assessments:
         for assessment in assessments:
 
             assessment_input = {

--- a/mlflow_export_import/trace/trace_utils.py
+++ b/mlflow_export_import/trace/trace_utils.py
@@ -108,12 +108,13 @@ def _get_span_params(span_data):
 
 
 def _write_trace_id_to_run(request_metadata, output_dir, trace_id, experiment_id):
-    if request_metadata.get("mlflow.sourceRun") and f"{experiment_id}/runs" in output_dir:
+    if request_metadata.get("mlflow.sourceRun") and "traces" in output_dir:
         run_id = request_metadata["mlflow.sourceRun"]
-        run_path = output_dir[:output_dir.index("traces")]
-        path = _fs.mk_local_path(os.path.join(run_path, "runs", run_id, 'run.json'))
-        root_dct = io_utils.read_file(path)
-        mlflow_dct = io_utils.get_mlflow(root_dct)
-
-        mlflow_dct.setdefault("traces", []).append(trace_id)
-        io_utils.write_file(path, root_dct)
+        run_path = output_dir[:output_dir.rfind("traces")]
+        run_json_path = _fs.mk_local_path(os.path.join(run_path, "runs", run_id, 'run.json'))
+        
+        if os.path.exists(run_json_path):
+            root_dct = io_utils.read_file(run_json_path)
+            mlflow_dct = io_utils.get_mlflow(root_dct)
+            mlflow_dct.setdefault("traces", []).append(trace_id)
+            io_utils.write_file(run_json_path, root_dct)


### PR DESCRIPTION
Summary of the Changes.

1. Added version check for logged models and traces to exit smoothly instead of raising unknown errors 
2. Additional check for assessments which was throwing NonType not iterable. 
3. Added additional status set for the run after logged model to restore the exported run status. 
    - After run is exported. Logged models are logging the metrics and marking the status as finished. which is removing the src run status
4. Fixed linking the model id to the registered model during import-all
5. Added robust logic check to restore run link with the traces during exporting. 