### PR TITLE
fix: support auth_type profiles (azure-cli, databricks-cli) in imports

### DIFF
--- a/mlflow_export_import/client/databricks_cli_utils.py
+++ b/mlflow_export_import/client/databricks_cli_utils.py
@@ -1,5 +1,4 @@
-from databricks_cli.configure import provider
-from mlflow.utils.databricks_utils import is_in_databricks_runtime
+from mlflow.utils.databricks_utils import get_databricks_host_creds
 
 
 def get_host_token_for_profile(profile=None):
@@ -7,13 +6,9 @@ def get_host_token_for_profile(profile=None):
     :param profile: Databricks profile as in ~/.databrickscfg or None for the default profile
     :return: tuple of (host, token) from the ~/.databrickscfg profile
     """
-    if profile:
-        cfg = provider.get_config_for_profile(profile)
-        if not cfg.host and is_in_databricks_runtime():
-            cfg = provider.get_config() 
-    else:
-        cfg = provider.get_config() 
-    return (cfg.host, cfg.token)
+    server_uri = f"databricks://{profile}" if profile else "databricks"
+    creds = get_databricks_host_creds(server_uri)
+    return (creds.host, creds.token)
 
 
 if __name__ == "__main__":

--- a/tests/open_source/test_databricks_auth.py
+++ b/tests/open_source/test_databricks_auth.py
@@ -1,0 +1,66 @@
+import textwrap
+from pathlib import Path
+from unittest import mock
+
+import pytest
+from mlflow.utils.rest_utils import MlflowHostCreds
+
+from mlflow_export_import.client import databricks_cli_utils
+
+
+@pytest.fixture
+def databricks_config(tmp_path: Path) -> Path:
+    content = textwrap.dedent("""
+        [DEFAULT]
+        host = https://default.azuredatabricks.net
+        auth_type = azure-cli
+
+        [explicit]
+        host = https://explicit.azuredatabricks.net
+        token = dapi_explicit_token
+
+        [azure-cli]
+        host = https://azure-cli.azuredatabricks.net
+        auth_type = azure-cli
+    """).strip()
+    config_file = tmp_path / "databrickscfg"
+    config_file.write_text(content)
+    return config_file
+
+
+class TestGetHostTokenForProfile:
+
+    def test_explicit_token_profile(
+        self,
+        databricks_config: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.setenv("DATABRICKS_CONFIG_FILE", str(databricks_config))
+
+        host, token = databricks_cli_utils.get_host_token_for_profile("explicit")
+
+        assert host == "https://explicit.azuredatabricks.net"
+        assert token == "dapi_explicit_token"
+
+    @pytest.mark.parametrize(("profile", "expected_uri"), [
+        ("azure-cli", "databricks://azure-cli"),
+        (None, "databricks"),
+    ])
+    def test_auth_type_profile(
+        self,
+        databricks_config: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        profile: str | None,
+        expected_uri: str,
+    ) -> None:
+        monkeypatch.setenv("DATABRICKS_CONFIG_FILE", str(databricks_config))
+        mock_creds = mock.Mock(spec=MlflowHostCreds, host="https://resolved.net", token="resolved_token")
+
+        with mock.patch(
+            "mlflow_export_import.client.databricks_cli_utils.get_databricks_host_creds",
+            return_value=mock_creds,
+        ) as mock_fn:
+            host, token = databricks_cli_utils.get_host_token_for_profile(profile)
+
+        mock_fn.assert_called_once_with(expected_uri)
+        assert (host, token) == ("https://resolved.net", "resolved_token")

--- a/tests/open_source/test_databricks_auth.py
+++ b/tests/open_source/test_databricks_auth.py
@@ -28,39 +28,35 @@ def databricks_config(tmp_path: Path) -> Path:
     return config_file
 
 
-class TestGetHostTokenForProfile:
+def test_explicit_token_profile(
+    databricks_config: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("DATABRICKS_CONFIG_FILE", str(databricks_config))
 
-    def test_explicit_token_profile(
-        self,
-        databricks_config: Path,
-        monkeypatch: pytest.MonkeyPatch,
-    ) -> None:
-        monkeypatch.setenv("DATABRICKS_CONFIG_FILE", str(databricks_config))
+    host, token = databricks_cli_utils.get_host_token_for_profile("explicit")
 
-        host, token = databricks_cli_utils.get_host_token_for_profile("explicit")
+    assert host == "https://explicit.azuredatabricks.net"
+    assert token == "dapi_explicit_token"
 
-        assert host == "https://explicit.azuredatabricks.net"
-        assert token == "dapi_explicit_token"
+@pytest.mark.parametrize(("profile", "expected_uri"), [
+    ("azure-cli", "databricks://azure-cli"),
+    (None, "databricks"),
+])
+def test_auth_type_profile(
+    databricks_config: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    profile: str | None,
+    expected_uri: str,
+) -> None:
+    monkeypatch.setenv("DATABRICKS_CONFIG_FILE", str(databricks_config))
+    mock_creds = mock.Mock(spec=MlflowHostCreds, host="https://resolved.net", token="resolved_token")
 
-    @pytest.mark.parametrize(("profile", "expected_uri"), [
-        ("azure-cli", "databricks://azure-cli"),
-        (None, "databricks"),
-    ])
-    def test_auth_type_profile(
-        self,
-        databricks_config: Path,
-        monkeypatch: pytest.MonkeyPatch,
-        profile: str | None,
-        expected_uri: str,
-    ) -> None:
-        monkeypatch.setenv("DATABRICKS_CONFIG_FILE", str(databricks_config))
-        mock_creds = mock.Mock(spec=MlflowHostCreds, host="https://resolved.net", token="resolved_token")
+    with mock.patch(
+        "mlflow_export_import.client.databricks_cli_utils.get_databricks_host_creds",
+        return_value=mock_creds,
+    ) as mock_fn:
+        host, token = databricks_cli_utils.get_host_token_for_profile(profile)
 
-        with mock.patch(
-            "mlflow_export_import.client.databricks_cli_utils.get_databricks_host_creds",
-            return_value=mock_creds,
-        ) as mock_fn:
-            host, token = databricks_cli_utils.get_host_token_for_profile(profile)
-
-        mock_fn.assert_called_once_with(expected_uri)
-        assert (host, token) == ("https://resolved.net", "resolved_token")
+    mock_fn.assert_called_once_with(expected_uri)
+    assert (host, token) == ("https://resolved.net", "resolved_token")


### PR DESCRIPTION
## Summary
- Replaces legacy `databricks-cli` provider with MLflow's `get_databricks_host_creds()` for credential resolution
- Enables federated authentication (azure-cli, databricks-cli) for import operations
- Adds tests for explicit token and auth_type profile handling

Fixes #228

## Test plan
- [x] `pytest tests/open_source/test_databricks_auth.py -v` passes
- [x] Manual verification with azure-cli profile