### PR TITLE
Fix opt_until function and default logging to INFO

### DIFF
--- a/README_bulk.md
+++ b/README_bulk.md
@@ -220,7 +220,7 @@ Options:
 ##### Export all models
 
 ```
-export-models --output-dir out
+export-models --output-dir out --models all
 ```
 
 ##### Export specified models

--- a/mlflow_export_import/bulk/export_experiments.py
+++ b/mlflow_export_import/bulk/export_experiments.py
@@ -16,7 +16,7 @@ from mlflow_export_import.common.click_options import (
     opt_export_permissions,
     opt_notebook_formats,
     opt_run_start_time,
-    opt_until,
+    opt_runs_until,
     opt_export_deleted_runs,
     opt_use_threads
 )
@@ -219,7 +219,7 @@ class Result:
 @opt_output_dir
 @opt_export_permissions
 @opt_run_start_time
-@opt_until
+@opt_runs_until
 @opt_export_deleted_runs
 @opt_notebook_formats
 @opt_use_threads

--- a/mlflow_export_import/common/click_options.py
+++ b/mlflow_export_import/common/click_options.py
@@ -70,7 +70,7 @@ def opt_run_start_time(function):
     )(function)
     return function
 
-def opt_until(function):
+def opt_runs_until(function):
     function = click.option("--runs-until",
         help="Only export runs started before this UTC time (exclusive). Use with --run-start-time to define a time window. Format: YYYY-MM-DD or YYYY-MM-DD HH:MM:SS.",
         type=str,

--- a/mlflow_export_import/common/default_logging_config.py
+++ b/mlflow_export_import/common/default_logging_config.py
@@ -22,7 +22,7 @@ config = {
     },
     "loggers": {
       "sampleLogger": {
-        "level": "DEBUG",
+        "level": "INFO",
         "handlers": [
           "console"
         ],
@@ -30,7 +30,7 @@ config = {
       }
     },
     "root": {
-      "level": "DEBUG",
+      "level": "INFO",
       "handlers": [
         "console",
         "file"

--- a/mlflow_export_import/experiment/export_experiment.py
+++ b/mlflow_export_import/experiment/export_experiment.py
@@ -14,7 +14,7 @@ from mlflow_export_import.common.click_options import (
     opt_notebook_formats,
     opt_export_permissions,
     opt_run_start_time,
-    opt_until,
+    opt_runs_until,
     opt_export_deleted_runs,
     opt_check_nested_runs
 )
@@ -218,7 +218,7 @@ def _get_runs(mlflow_client, run_ids, exp, failed_run_ids):
 @opt_run_ids
 @opt_export_permissions
 @opt_run_start_time
-@opt_until
+@opt_runs_until
 @opt_export_deleted_runs
 @opt_check_nested_runs
 @opt_notebook_formats


### PR DESCRIPTION
### Fixes
- Fixed bug in #225 where `opt_runs_until` was incorrectly referenced as `opt_until` in some places, causing errors
- Fixed example for exporting all models
- Changed default logging level from DEBUG to INFO to reduce log verbosity and improve readability