### PR TITLE
fix: preserve model version tags in OSS bulk export

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 __pycache__/
+.venv/
+*.egg-info/

--- a/mlflow_export_import/common/model_utils.py
+++ b/mlflow_export_import/common/model_utils.py
@@ -76,7 +76,8 @@ def list_model_versions(client, model_name, get_latest_versions=False):
         if get_latest_versions:
             return client.get_latest_versions(model_name)
         else:
-            return list(SearchModelVersionsIterator(client, filter=f"name='{model_name}'"))
+            versions = SearchModelVersionsIterator(client, filter=f"name='{model_name}'")
+            return [ client.get_model_version(vr.name, vr.version) for vr in versions ]
 
 
 def search_model_versions(client, filter):

--- a/tests/open_source/test_model_utils.py
+++ b/tests/open_source/test_model_utils.py
@@ -1,0 +1,22 @@
+from types import SimpleNamespace
+from unittest import mock
+from mlflow_export_import.common.model_utils import list_model_versions
+
+
+def test_list_model_versions_fetches_full_version_for_oss():
+    """
+    Regression test for issue #240.
+    search_model_versions omits tags on PostgreSQL backends. list_model_versions
+    must call get_model_version per version so tags are present in exported metadata.
+    """
+    mock_client = mock.Mock()
+    full_version = SimpleNamespace(tags={"env": "prod"})
+    mock_client.get_model_version.return_value = full_version
+
+    with mock.patch(
+        "mlflow_export_import.common.model_utils.SearchModelVersionsIterator",
+        return_value=iter([SimpleNamespace(name="m", version="1")]),
+    ):
+        result = list_model_versions(mock_client, "m")
+
+    assert result == [full_version]


### PR DESCRIPTION
## Summary

Fixes #240.

On PostgreSQL backends, `search_model_versions` (used by `SearchModelVersionsIterator`) does not return tags or aliases on model versions. The non-UC path in `list_model_versions` was returning raw search results directly, so version tags were silently dropped during export.

The UC path already handled this correctly by calling `get_model_version` per version. This PR applies the same approach to the non-UC path.