### PR TITLE
fix: read timestamps without an offset as UTC

### DIFF
--- a/mlflow_export_import/common/timestamp_utils.py
+++ b/mlflow_export_import/common/timestamp_utils.py
@@ -1,5 +1,5 @@
 import time
-from datetime import datetime
+from datetime import datetime, timezone
 
 
 TS_FORMAT = "%Y-%m-%d %H:%M:%S"
@@ -34,17 +34,11 @@ def utc_str_to_millis(sdt):
 
 
 def utc_str_to_seconds(sdt):
-    """ Convert UTC string to epoch seconds. """
-    from datetime import timezone
+    """ Convert UTC string to epoch seconds. A value without an offset is treated as UTC. """
     dt = datetime.fromisoformat(sdt)
-    # If datetime is naive (no timezone), treat it as local time
     if dt.tzinfo is None:
-        # Convert to timestamp using local timezone
-        seconds = dt.timestamp()
-    else:
-        # If timezone-aware, convert to UTC and get timestamp
-        seconds = dt.timestamp()
-    return seconds
+        dt = dt.replace(tzinfo=timezone.utc)
+    return dt.timestamp()
 
 
 def adjust_timestamps(dct, keys):

--- a/tests/open_source/test_timestamp_utils.py
+++ b/tests/open_source/test_timestamp_utils.py
@@ -1,0 +1,90 @@
+"""
+Test the timestamp conversion utilities.
+"""
+
+import os
+import time
+import pytest
+
+from mlflow_export_import.common.timestamp_utils import (
+    utc_str_to_seconds,
+    utc_str_to_millis,
+    fmt_ts_millis
+)
+
+
+pytestmark = pytest.mark.skipif(
+    not hasattr(time, "tzset"),
+    reason="time.tzset() is only available on Unix"
+)
+
+
+_winter_seconds = 1704067200 # 2024-01-01 00:00:00 UTC
+_summer_seconds = 1719792000 # 2024-07-01 00:00:00 UTC
+_timezones = [ "UTC", "America/Los_Angeles", "Asia/Kolkata" ]
+
+
+@pytest.fixture
+def set_timezone():
+    """ Set the process timezone for one test and restore it afterwards. """
+    # not monkeypatch.setenv, since tzset must run after TZ is restored
+    saved = os.environ.get("TZ")
+    def _set(name):
+        os.environ["TZ"] = name
+        time.tzset()
+        if name != "UTC" and time.strftime("%z", time.localtime(_winter_seconds)) == "+0000":
+            pytest.skip(f"no timezone database entry for {name}")
+    yield _set
+    if saved is None:
+        os.environ.pop("TZ", None)
+    else:
+        os.environ["TZ"] = saved
+    time.tzset()
+
+
+# == Test strings without an offset are read as UTC
+
+@pytest.mark.parametrize("timezone_name", _timezones)
+def test_naive_string_is_utc(set_timezone, timezone_name):
+    set_timezone(timezone_name)
+    assert _winter_seconds == utc_str_to_seconds("2024-01-01 00:00:00")
+
+
+@pytest.mark.parametrize("timezone_name", _timezones)
+def test_naive_date_only_string_is_utc(set_timezone, timezone_name):
+    set_timezone(timezone_name)
+    assert _winter_seconds * 1000 == utc_str_to_millis("2024-01-01")
+
+
+@pytest.mark.parametrize("timezone_name", _timezones)
+def test_naive_string_is_utc_during_daylight_saving(set_timezone, timezone_name):
+    set_timezone(timezone_name)
+    assert _summer_seconds == utc_str_to_seconds("2024-07-01 00:00:00")
+
+
+@pytest.mark.parametrize("timezone_name", _timezones)
+def test_round_trip_with_fmt_ts_millis(set_timezone, timezone_name):
+    set_timezone(timezone_name)
+    millis = utc_str_to_millis("2024-01-01 00:00:00")
+    assert "2024-01-01 00:00:00" == fmt_ts_millis(millis)
+
+
+# == Test strings with an offset
+
+@pytest.mark.parametrize("timezone_name", _timezones)
+def test_utc_offset_is_honored(set_timezone, timezone_name):
+    set_timezone(timezone_name)
+    assert _winter_seconds == utc_str_to_seconds("2024-01-01T00:00:00+00:00")
+
+
+@pytest.mark.parametrize("timezone_name", _timezones)
+def test_non_utc_offset_is_honored(set_timezone, timezone_name):
+    set_timezone(timezone_name)
+    assert _winter_seconds - (5*3600 + 30*60) == utc_str_to_seconds("2024-01-01T00:00:00+05:30")
+    assert _winter_seconds + 8*3600 == utc_str_to_seconds("2024-01-01T00:00:00-08:00")
+
+
+# == Test milliseconds conversion
+
+def test_utc_str_to_millis_returns_int():
+    assert isinstance(utc_str_to_millis("2024-01-01"), int)


### PR DESCRIPTION
## Summary

utc_str_to_seconds parsed a timestamp with no offset as local time, so the run start time and runs until filters were off by the host offset although the CLI help and READMEs document them as UTC. Values that carry an offset are not affected. Naive values are now read as UTC, which is what the function did before 5bef896.

Fixes #246

## Test plan

Added tests/open_source/test_timestamp_utils.py, 19 tests over three timezones. Against master 8 of them fail, the naive value cases outside UTC. All 19 pass here. No server needed.
